### PR TITLE
add binds to move across windows and sessions, and swap between windows

### DIFF
--- a/main.tmux
+++ b/main.tmux
@@ -38,3 +38,7 @@ tmux bind                   h                      previous-window
 tmux bind                   j                      switch-client -n
 tmux bind                   k                      switch-client -p
 tmux bind                   l                      next-window
+
+tmux bind                   C-M-h                  swap-window -t:-1
+tmux bind                   C-M-l                  swap-window -t:+1
+

--- a/main.tmux
+++ b/main.tmux
@@ -4,40 +4,49 @@ is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)
 is_fzf="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?fzf$'"
 is_lazygit="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?lazygit$'"
 
-tmux bind -n              C-h     if "$is_vim"                           "send C-h" "select-pane -L"
-tmux bind -n              C-j     if "$is_vim || $is_fzf || $is_lazygit" "send C-j" "select-pane -D"
-tmux bind -n              C-k     if "$is_vim || $is_fzf || $is_lazygit" "send C-k" "select-pane -U"
-tmux bind -n              C-l     if "$is_vim"                           "send C-l" "select-pane -R"
+# Smart pane navigation with Vim/fzf/lazygit awareness
+tmux bind -N "Select pane on the left"  -n C-h if "$is_vim"                           "send C-h" "select-pane -L"
+tmux bind -N "Select pane below"        -n C-j if "$is_vim || $is_fzf || $is_lazygit" "send C-j" "select-pane -D"
+tmux bind -N "Select pane above"        -n C-k if "$is_vim || $is_fzf || $is_lazygit" "send C-k" "select-pane -U"
+tmux bind -N "Select pane on the right" -n C-l if "$is_vim"                           "send C-l" "select-pane -R"
 
-tmux bind -r              C-h     send C-h
-tmux bind -r              C-j     send C-j
-tmux bind -r              C-k     send C-k
-tmux bind -r              C-l     send C-l
+# Send keys directly
+tmux bind -N "Send C-h to the active pane" -r C-h send C-h
+tmux bind -N "Send C-j to the active pane" -r C-j send C-j
+tmux bind -N "Send C-k to the active pane" -r C-k send C-k
+tmux bind -N "Send C-l to the active pane" -r C-l send C-l
 
-tmux bind                 H       swap-pane -s "{left-of}"
-tmux bind                 J       swap-pane -s "{down-of}"
-tmux bind                 K       swap-pane -s "{up-of}"
-tmux bind                 L       swap-pane -s "{right-of}"
+# Swap panes
+tmux bind -N "Swap the active pane with the pane on the left"  H swap-pane -s "{left-of}"
+tmux bind -N "Swap the active pane with the pane below"        J swap-pane -s "{down-of}"
+tmux bind -N "Swap the active pane with the pane above"        K swap-pane -s "{up-of}"
+tmux bind -N "Swap the active pane with the pane on the right" L swap-pane -s "{right-of}"
 
-tmux bind -n              C-Left  if "$is_vim" "send C-Left"  "resize-pane -L 3"
-tmux bind -n              C-Down  if "$is_vim" "send C-Down"  "resize-pane -D 3"
-tmux bind -n              C-Up    if "$is_vim" "send C-Up"    "resize-pane -U 3"
-tmux bind -n              C-Right if "$is_vim" "send C-Right" "resize-pane -R 3"
+# Resize panes with Ctrl + Arrow
+tmux bind -N "Resize pane left by 3"  -n C-Left  if "$is_vim" "send C-Left"  "resize-pane -L 3"
+tmux bind -N "Resize pane down by 3"  -n C-Down  if "$is_vim" "send C-Down"  "resize-pane -D 3"
+tmux bind -N "Resize pane up by 3"    -n C-Up    if "$is_vim" "send C-Up"    "resize-pane -U 3"
+tmux bind -N "Resize pane right by 3" -n C-Right if "$is_vim" "send C-Right" "resize-pane -R 3"
 
-tmux bind -T copy-mode-vi C-h     select-pane -L
-tmux bind -T copy-mode-vi C-j     select-pane -D
-tmux bind -T copy-mode-vi C-k     select-pane -U
-tmux bind -T copy-mode-vi C-l     select-pane -R
+# Copy-mode (VI) navigation
+tmux bind -N "Select pane on the left"  -T copy-mode-vi C-h select-pane -L
+tmux bind -N "Select pane below"        -T copy-mode-vi C-j select-pane -D
+tmux bind -N "Select pane above"        -T copy-mode-vi C-k select-pane -U
+tmux bind -N "Select pane on the right" -T copy-mode-vi C-l select-pane -R
 
-tmux bind -T copy-mode-vi C-Left  resize-pane -L 3
-tmux bind -T copy-mode-vi C-Down  resize-pane -D 3
-tmux bind -T copy-mode-vi C-Up    resize-pane -U 3
-tmux bind -T copy-mode-vi C-Right resize-pane -R 3
+# Copy-mode (VI) resize
+tmux bind -N "Resize pane left by 3"  -T copy-mode-vi C-Left  resize-pane -L 3
+tmux bind -N "Resize pane down by 3"  -T copy-mode-vi C-Down  resize-pane -D 3
+tmux bind -N "Resize pane up by 3"    -T copy-mode-vi C-Up    resize-pane -U 3
+tmux bind -N "Resize pane right by 3" -T copy-mode-vi C-Right resize-pane -R 3
 
-tmux bind                 h       previous-window
-tmux bind                 j       switch-client -n
-tmux bind                 k       switch-client -p
-tmux bind                 l       next-window
+# Window and Client navigation
+tmux bind -N "Select the previous window" h previous-window
+tmux bind -N "Switch to next client"      j switch-client -n
+tmux bind -N "Switch to previous client"  k switch-client -p
+tmux bind -N "Select the next window"     l next-window
 
-tmux bind                 C-M-h   'swap-window -t:-1; previous-window'
-tmux bind                 C-M-l   'swap-window -t:+1; next-window'
+# Swap windows
+tmux bind -N "Swap window with previous" C-M-h 'swap-window -t:-1; previous-window'
+tmux bind -N "Swap window with next"     C-M-l 'swap-window -t:+1; next-window'
+

--- a/main.tmux
+++ b/main.tmux
@@ -33,3 +33,8 @@ tmux bind -T copy-mode-vi   C-Left                 resize-pane -L 3
 tmux bind -T copy-mode-vi   C-Down                 resize-pane -D 3
 tmux bind -T copy-mode-vi   C-Up                   resize-pane -U 3
 tmux bind -T copy-mode-vi   C-Right                resize-pane -R 3
+
+tmux bind                   h                      previous-window
+tmux bind                   j                      switch-client -n
+tmux bind                   k                      switch-client -p
+tmux bind                   l                      next-window

--- a/main.tmux
+++ b/main.tmux
@@ -4,41 +4,40 @@ is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)
 is_fzf="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?fzf$'"
 is_lazygit="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?lazygit$'"
 
-tmux bind -n                C-h                    if "$is_vim"                           "send C-h" "select-pane -L"
-tmux bind -n                C-j                    if "$is_vim || $is_fzf || $is_lazygit" "send C-j" "select-pane -D"
-tmux bind -n                C-k                    if "$is_vim || $is_fzf || $is_lazygit" "send C-k" "select-pane -U"
-tmux bind -n                C-l                    if "$is_vim"                           "send C-l" "select-pane -R"
+tmux bind -n              C-h     if "$is_vim"                           "send C-h" "select-pane -L"
+tmux bind -n              C-j     if "$is_vim || $is_fzf || $is_lazygit" "send C-j" "select-pane -D"
+tmux bind -n              C-k     if "$is_vim || $is_fzf || $is_lazygit" "send C-k" "select-pane -U"
+tmux bind -n              C-l     if "$is_vim"                           "send C-l" "select-pane -R"
 
-tmux bind -r                C-h                    send C-h
-tmux bind -r                C-j                    send C-j
-tmux bind -r                C-k                    send C-k
-tmux bind -r                C-l                    send C-l
+tmux bind -r              C-h     send C-h
+tmux bind -r              C-j     send C-j
+tmux bind -r              C-k     send C-k
+tmux bind -r              C-l     send C-l
 
-tmux bind                   H                      swap-pane -s "{left-of}"
-tmux bind                   J                      swap-pane -s "{down-of}"
-tmux bind                   K                      swap-pane -s "{up-of}"
-tmux bind                   L                      swap-pane -s "{right-of}"
+tmux bind                 H       swap-pane -s "{left-of}"
+tmux bind                 J       swap-pane -s "{down-of}"
+tmux bind                 K       swap-pane -s "{up-of}"
+tmux bind                 L       swap-pane -s "{right-of}"
 
-tmux bind -n                C-Left                 if "$is_vim" "send C-Left"  "resize-pane -L 3"
-tmux bind -n                C-Down                 if "$is_vim" "send C-Down"  "resize-pane -D 3"
-tmux bind -n                C-Up                   if "$is_vim" "send C-Up"    "resize-pane -U 3"
-tmux bind -n                C-Right                if "$is_vim" "send C-Right" "resize-pane -R 3"
+tmux bind -n              C-Left  if "$is_vim" "send C-Left"  "resize-pane -L 3"
+tmux bind -n              C-Down  if "$is_vim" "send C-Down"  "resize-pane -D 3"
+tmux bind -n              C-Up    if "$is_vim" "send C-Up"    "resize-pane -U 3"
+tmux bind -n              C-Right if "$is_vim" "send C-Right" "resize-pane -R 3"
 
-tmux bind -T copy-mode-vi   C-h                    select-pane -L
-tmux bind -T copy-mode-vi   C-j                    select-pane -D
-tmux bind -T copy-mode-vi   C-k                    select-pane -U
-tmux bind -T copy-mode-vi   C-l                    select-pane -R
+tmux bind -T copy-mode-vi C-h     select-pane -L
+tmux bind -T copy-mode-vi C-j     select-pane -D
+tmux bind -T copy-mode-vi C-k     select-pane -U
+tmux bind -T copy-mode-vi C-l     select-pane -R
 
-tmux bind -T copy-mode-vi   C-Left                 resize-pane -L 3
-tmux bind -T copy-mode-vi   C-Down                 resize-pane -D 3
-tmux bind -T copy-mode-vi   C-Up                   resize-pane -U 3
-tmux bind -T copy-mode-vi   C-Right                resize-pane -R 3
+tmux bind -T copy-mode-vi C-Left  resize-pane -L 3
+tmux bind -T copy-mode-vi C-Down  resize-pane -D 3
+tmux bind -T copy-mode-vi C-Up    resize-pane -U 3
+tmux bind -T copy-mode-vi C-Right resize-pane -R 3
 
-tmux bind                   h                      previous-window
-tmux bind                   j                      switch-client -n
-tmux bind                   k                      switch-client -p
-tmux bind                   l                      next-window
+tmux bind                 h       previous-window
+tmux bind                 j       switch-client -n
+tmux bind                 k       switch-client -p
+tmux bind                 l       next-window
 
-tmux bind                   C-M-h                  swap-window -t:-1
-tmux bind                   C-M-l                  swap-window -t:+1
-
+tmux bind                 C-M-h   'swap-window -t:-1; previous-window'
+tmux bind                 C-M-l   'swap-window -t:+1; next-window'


### PR DESCRIPTION
I really like this plugin, is really great to do everything with panes with vim-motions, and I think is a great idea to do the same with windows and sessions, so I add 6 new binds, to move across the windows and panes, and swap windows with vim-motions:

```shell
tmux bind h previous-window
tmux bind j switch-client -n
tmux bind k switch-client -p
tmux bind l next-window

tmux bind C-M-h swap-window -t:-1
tmux bind C-M-l swap-window -t:+1
```

I use this exact same keys in my config for a long time, and is to much better to manipulate windows and sessions.

Since tmux doesn't have a out-of-the-box way to swap sessions, I don't to that, but I think it can be done with a custom script
